### PR TITLE
Hotfix/log external auth

### DIFF
--- a/app/controllers/custom/users/sessions_controller.rb
+++ b/app/controllers/custom/users/sessions_controller.rb
@@ -57,17 +57,26 @@ class Users::SessionsController < Devise::SessionsController
       unless user_signed_in?
         @ip = request.remote_ip
         @managementIps = nil
+        Rails.logger.debug "verifyIp: IP remota: #{@ip}"
+        Rails.logger.debug "verifyIp: La ip de cliente es: #{request.ip}"
         if(Rails.application.config.respond_to?(:participacion_management_ip))
           @managementIps = Rails.application.config.participacion_management_ip
         end
         if(Rails.application.config.respond_to?(:participacion_renegotiation))
           @redirect = Rails.application.config.participacion_renegotiation
         end
+        Rails.logger.debug "verifyIp: IP de gestión #{@managementIps}"
+        Rails.logger.debug "verifyIp: IP de redirección #{@redirect}"
 
         if(@redirect!=nil)
+          Rails.logger.debug "verifyIp: IP de redirección no nula, verificando IPs de gestión"
+          @managementIps.split(';').each{|m| Rails.logger.debug "verifyIp: --- evaluando [#{m.strip}] #{(m.strip == @ip)}"}
+
           if(@managementIps==nil || @managementIps.split(';').none?{|m| m.strip == @ip })
+            Rails.logger.debug "verifyIp: Generando redirect a #{@redirect} no hemos localizado ips validas"
             redirect_to @redirect, :status => 302
           end
+          Rails.logger.debug "verifyIp: Generando redirect a #{@redirect}"
         end
       end
     end

--- a/app/controllers/custom/users/sessions_controller.rb
+++ b/app/controllers/custom/users/sessions_controller.rb
@@ -28,9 +28,9 @@ class Users::SessionsController < Devise::SessionsController
   private
 
     def after_sign_in_path_for(resource)
-      @returnTo = stored_location_for(resource);
-      if(@returnTo!=nil)
-        @returnTo
+      returnTo = stored_location_for(resource);
+      if(returnTo!=nil)
+        returnTo
       else
         root_path
       end
@@ -57,26 +57,26 @@ class Users::SessionsController < Devise::SessionsController
       unless user_signed_in?
         # Usamos el request.ip, el remote_ip no parece dar resultados correctos en el entorno
         # del Ayto
-        @ip = request.ip
-        @managementIps = nil
-        Rails.logger.debug "verifyIp: IP remota: #{@ip}"
+        ip = request.ip
+        managementIps = nil
+        Rails.logger.debug "verifyIp: IP remota: #{ip}"
         Rails.logger.debug "verifyIp: La ip de cliente es: #{request.ip}"
         if(Rails.application.config.respond_to?(:participacion_management_ip))
-          @managementIps = Rails.application.config.participacion_management_ip
+          managementIps = Rails.application.config.participacion_management_ip
         end
         if(Rails.application.config.respond_to?(:participacion_renegotiation))
-          @redirect = Rails.application.config.participacion_renegotiation
+          redirect = Rails.application.config.participacion_renegotiation
         end
-        Rails.logger.debug "verifyIp: IP de gestión #{@managementIps}"
-        Rails.logger.debug "verifyIp: IP de redirección #{@redirect}"
+        Rails.logger.debug "verifyIp: IP de gestión #{managementIps}"
+        Rails.logger.debug "verifyIp: IP de redirección #{redirect}"
 
-        if(@redirect!=nil)
+        if(redirect!=nil)
           Rails.logger.debug "verifyIp: IP de redirección no nula, verificando IPs de gestión"
-          @managementIps.split(';').each{|m| Rails.logger.debug "verifyIp: --- evaluando [#{m.strip}] #{(m.strip == @ip)}"}
+          managementIps.split(';').each{|m| Rails.logger.debug "verifyIp: --- evaluando [#{m.strip}] #{(m.strip == ip)}"}
 
-          if(@managementIps==nil || @managementIps.split(';').none?{|m| m.strip == @ip })
-            Rails.logger.debug "verifyIp: Generando redirect a #{@redirect} no hemos localizado ips validas"
-            redirect_to @redirect, :status => 302
+          if(managementIps==nil || managementIps.split(';').none?{|m| m.strip == ip })
+            Rails.logger.debug "verifyIp: Generando redirect a #{redirect} no hemos localizado ips validas"
+            redirect_to redirect, :status => 302
           end
           Rails.logger.debug "verifyIp: Success!"
         end

--- a/app/controllers/custom/users/sessions_controller.rb
+++ b/app/controllers/custom/users/sessions_controller.rb
@@ -55,7 +55,9 @@ class Users::SessionsController < Devise::SessionsController
       # en caso negativo redirigimos la petición a la de renegociacion
       # del portal de participacion.. siempre y cuando el usuario no este conectado ya, claro...
       unless user_signed_in?
-        @ip = request.remote_ip
+        # Usamos el request.ip, el remote_ip no parece dar resultados correctos en el entorno
+        # del Ayto
+        @ip = request.ip
         @managementIps = nil
         Rails.logger.debug "verifyIp: IP remota: #{@ip}"
         Rails.logger.debug "verifyIp: La ip de cliente es: #{request.ip}"
@@ -76,7 +78,7 @@ class Users::SessionsController < Devise::SessionsController
             Rails.logger.debug "verifyIp: Generando redirect a #{@redirect} no hemos localizado ips validas"
             redirect_to @redirect, :status => 302
           end
-          Rails.logger.debug "verifyIp: Generando redirect a #{@redirect}"
+          Rails.logger.debug "verifyIp: Success!"
         end
       end
     end

--- a/app/controllers/external_user_controller.rb
+++ b/app/controllers/external_user_controller.rb
@@ -37,6 +37,9 @@ class ExternalUserController < ApplicationController
       # El secreto y el origen valido almacenado
       secret = nil
       origin = nil
+      Rails.logger.debug "verify_participacion_token: Tenemos xauth-token: [#{xauth}] con ip remota: #{ip}"
+      Rails.logger.debug "verify_participacion_token: La ip de cliente es: #{request.ip}"
+
       if(Rails.application.config.respond_to?(:participacion_xauth_secret))
         secret = Rails.application.config.participacion_xauth_secret.strip
       end
@@ -44,17 +47,24 @@ class ExternalUserController < ApplicationController
         origin = Rails.application.config.participacion_xauth_origin.strip
       end
 
+      Rails.logger.debug "verify_participacion_token: Comprobando xauth-token: [#{(secret == xauth)}] con ip remota registrada: [#{origin}]"
+
       # Verificamos que tenemos todos los datos
       if (secret == nil || origin == nil || xauth == nil || xauth != secret)
+        Rails.logger.debug "verify_participacion_token: Alguno de los datos es nulo o el secreto no es válido"
         render plain: 'unknown', status: :not_found
         return
       end
 
+      origin.split(';').each{|m| Rails.logger.debug "verifyIp: --- evaluando [#{m.strip}] #{(m.strip == ip)}"}
+
       # Ahora comprobamos... si alguna ip coincide
       if(origin.split(';').none? {|m| m.strip == ip})
+        Rails.logger.debug "verify_participacion_token: No hay coincidencia de IPs"
         render plain: 'unknown', status: :not_found
         return
       end
+      Rails.logger.debug "verify_participacion_token: Success"
 
     end
 

--- a/app/controllers/external_user_controller.rb
+++ b/app/controllers/external_user_controller.rb
@@ -33,7 +33,8 @@ class ExternalUserController < ApplicationController
       if(xauth!=nil)
         xauth = xauth.strip
       end
-      ip = request.remote_ip
+      # Utilizamos directamente la IP de la request, el remote_ip no parece gustar demasiado...
+      ip = request.ip
       # El secreto y el origen valido almacenado
       secret = nil
       origin = nil


### PR DESCRIPTION
## 
# Bug Fixes
##
* Uso de `request.ip` en lugar de `request.remote_ip`, el segundo daba en el entorno del Ayto la IP 127.0.0.1, con lo cual no funcionaba ninguno de los procedimientos de autenticación o acceso en modo gestión
* Cambio de variables de instancia en el `sessions_controller.rb` a variables locales, no tiene sentido que sean de instancia al no usarse en la vista.