### PR TITLE
Hotfix/auth no email

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -475,6 +475,18 @@ body.management .admin-content {
         }
       }
     }
+    .img {
+      .img-holder {
+        width: 100%;
+        height: 100%;
+
+        img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+        }
+      }
+    }
     .info {
       background-color: transparent;
       .pre-title {
@@ -506,8 +518,9 @@ body.management .admin-content {
         font-size: $font-size-base-small;
       }
 
+
       @media screen and (min-width: 64em) {
-        .decorated-on-large {
+        /*.decorated-on-large {
           max-width: 50%;
         }
         background-image: image-url("background-budgets.jpg");
@@ -522,7 +535,8 @@ body.management .admin-content {
             padding-right: 0px;
           }
           background-size: contain;
-        }
+        }*/
+
 
       }
     }

--- a/app/strategies/participacion_token_strategy.rb
+++ b/app/strategies/participacion_token_strategy.rb
@@ -65,6 +65,10 @@ class ParticipacionTokenStrategy < Warden::Strategies::Base
             u.verified_at = DateTime.current
         end
 
+        # Podemos no tener email de los usuarios que provienen del sistema externo,
+        # por ejemplo usuarios
+        u.skip_email_validation = true
+
         u.save!
 
       end

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -23,8 +23,7 @@
             <%= link_to t("budgets.index.section_header.help"), "#section_help" %>
           </p>
       </div>
-      <div class="small-12 medium-5 large-6 column info padding " data-equalizer-watch>
-        <div class="decorated-on-large">
+      <div class="small-12 medium-3 large-3 column info padding " data-equalizer-watch>
           <p class="pre-title">
             <strong><%= t("budgets.show.phase") %></strong>
           </p>
@@ -52,6 +51,10 @@
                         budget_results_path(current_budget, heading_id: current_budget.headings.first),
                         class: "button margin-top expanded" %>
           <% end %>
+      </div>
+      <div class="column img hide-for-small-only medium-2 large-3" data-equalizer-watch>
+        <div class="img-holder">
+          <%= image_tag "background-budgets.jpg", alt: "" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Bug Fixes
* No se visualizaba correctamente el texto de `inscripción`, se sobreimpresionaba a la imagen de fondo
* No se permitía el registro de usuarios sin email (provenientes de Cl@ve, p.ej. en el que pueden no tener email)
