### PR TITLE
Hofix/duplicate user names

### DIFF
--- a/app/models/custom/user.rb
+++ b/app/models/custom/user.rb
@@ -23,6 +23,11 @@ class User < ApplicationRecord
     signature_sheet_officer.present?
   end
 
+  def username_required?
+    return false if origin_participacion
+    !organization? && !erased?
+  end
+
   # Queremos evitar que podamos autenticarnos como usuarios de participacion
   # externos... que la clave es una de mentira...
   def self.find_for_database_authentication(warden_conditions)

--- a/app/strategies/participacion_token_strategy.rb
+++ b/app/strategies/participacion_token_strategy.rb
@@ -23,8 +23,8 @@ class ParticipacionTokenStrategy < Warden::Strategies::Base
       if(u)
         u.participacion_id = eu.participacion_id
         hasChanges = false
-        if(eu.fullname != u.username)
-          u.username = eu.fullname
+        if(eu.fullname[0..60] != u.username)
+          u.username = eu.fullname[0..60]
           hasChanges = true
         end
         if(eu.validated && !u.level_three_verified?)
@@ -48,7 +48,7 @@ class ParticipacionTokenStrategy < Warden::Strategies::Base
         u.save! if(hasChanges)
       else
         u = User.new(
-                    username: eu.fullname,
+                    username: eu.fullname[0..60],
                     email: eu.email,
                     confirmed_at: DateTime.current,
                     password: Devise.friendly_token[0, 20],
@@ -66,7 +66,7 @@ class ParticipacionTokenStrategy < Warden::Strategies::Base
         end
 
         # Podemos no tener email de los usuarios que provienen del sistema externo,
-        # por ejemplo usuarios
+        # por ejemplo usuarios con certificado
         u.skip_email_validation = true
 
         u.save!


### PR DESCRIPTION
Corrección de un par de errores/características de CONSUL base
* Permitimos duplicidad de nombre completo de usuario en el caso de que el origen sea participación 
* Truncamos a 60 caracteres el nombre para evitar problemas con el tamaño máximo del campo en BBDD