### PR TITLE
Hotfix/include bocadillo

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1061,3 +1061,31 @@ body.iframed {
     }
   }
 }
+
+@mixin bocadillo($pctg) {
+  div.ellipse {
+    background-color: #45597e;
+    height: 392px * $pctg;
+    width: 570px * $pctg;
+    margin-left: auto;
+    margin-right: auto;
+    border-radius: 50%;
+    transform: rotate(-10deg);
+    position: relative;
+    z-index: 2;
+    &:after {
+      content: '';
+      width: 0;
+      height: 0;
+      border-left: 50px * $pctg solid transparent;
+      border-right: 50px * $pctg solid transparent;
+      border-top: 100px * $pctg solid #45597e;
+      display: block;
+      position: absolute;
+      right: 90px;
+      z-index: 1;
+      bottom: -60px;
+      transform: rotate(-30deg);
+    }
+  }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -491,6 +491,7 @@ body.management .admin-content {
     }
     .img {
       padding-right: 0px;
+      padding-left: 0px;
       .img-holder {
         width: 100%;
         height: 100%;
@@ -1062,30 +1063,149 @@ body.iframed {
   }
 }
 
-@mixin bocadillo($pctg) {
-  div.ellipse {
-    background-color: #45597e;
+@mixin bocadillo($pctg, $participacion-bg-color: #E6118F) {
+  height: 392px * $pctg;
+  width: 570px * $pctg;
+  margin-left: auto;
+  margin-right: auto;
+
+  > div.ellipse {
+    background-color: $participacion-bg-color;
     height: 392px * $pctg;
     width: 570px * $pctg;
     margin-left: auto;
     margin-right: auto;
     border-radius: 50%;
     transform: rotate(-10deg);
-    position: relative;
+    position: absolute;
     z-index: 2;
+
     &:after {
       content: '';
       width: 0;
       height: 0;
       border-left: 50px * $pctg solid transparent;
       border-right: 50px * $pctg solid transparent;
-      border-top: 100px * $pctg solid #45597e;
+      border-top: 100px * $pctg solid $participacion-bg-color;
       display: block;
       position: absolute;
-      right: 90px;
+      right: 90px * $pctg;
       z-index: 1;
-      bottom: -60px;
+      bottom: -60px * $pctg;
       transform: rotate(-30deg);
     }
+
+  }
+  > div.bocadillo-text {
+    padding-top: 20%;
+    position: relative;
+    z-index: 3;
+    text-align: center;
+    > h2.heading {
+      font-family: "Nunito Black";
+      font-size: 90px * $pctg;
+      font-weight: bold;
+      text-transform: uppercase;
+      transform: scaleY(1.2);
+      position: relative;
+      color: yellow !important;
+      display: block;
+      margin-bottom: 0px;
+      line-height: 1.1;
+    }
+
+    > p.text,
+    > p.text-small,
+    > div.actions {
+      text-align: left;
+      padding: 0px;
+      padding-left: 89px * $pctg;
+      padding-right: 77px * $pctg;
+      font-family: "Nunito Bold";
+      color: white;
+      font-size: 30px * $pctg;
+      margin-bottom: 0px;
+
+      line-height: 1.1;
+
+      em {
+        text-transform: none;
+        font-style: normal;
+        color: yellow;
+        font-size: 31px * $pctg;
+      }
+      strong {
+        color: inherit !important;
+        font-size: 31px * $pctg;
+        font-family: "Nunito Black";
+      }
+    }
+    > p.text-small {
+      font-size: 26px * $pctg;
+      em {
+        font-size: 28px * $pctg;
+      }
+    }
+    > div.actions {
+      margin-top: 6px;
+      font-size: 28px * $pctg;
+      .call {
+        background: yellow;
+        color: $participacion-bg-color;
+        text-transform: uppercase;
+        padding: 0 6px;
+      }
+      a.phone {
+        &:before {
+          content: '\f095';
+          font-family: "Font Awesome 5 Free";
+          display: inline-block;
+          padding: 0 6px;
+          transform: rotate(90deg);
+        }
+        color: yellow !important;
+        font-size: inherit !important;
+      }
+    }
+  }
+
+}
+
+@mixin bocadillo-wrapper($default-bocadillos-size) {
+  $main-color: #E6118F;
+  margin-top: 20px;
+  @include bocadillo($default-bocadillos-size,$main-color);
+  .small-bocadillo {
+    @include bocadillo($default-bocadillos-size/4,white);
+    display: inline-block;
+    position: relative;
+    top:  - rem-calc(70 * $default-bocadillos-size);
+    right: 15px;
+    > div.ellipse {
+      transform: rotateZ(10deg) rotateY(-180deg);
+    }
+    > div.bocadillo-text {
+      > div.title {
+        color: $main-color;
+        font-size: 60px * $default-bocadillos-size;
+        font-weight: bold;
+        text-transform: uppercase;
+        line-height: 1;
+        margin: 0px;
+        text-decoration: none;
+        border-bottom: 0px;
+        letter-spacing: -1px;
+      }
+    }
+  }
+}
+
+.main-bocadillo {
+  @include bocadillo-wrapper(0.5);
+  @media screen and (min-width: 40rem) {
+    @include bocadillo-wrapper(0.35);
+  }
+  @media screen and (min-width: 60rem) {
+    @include bocadillo-wrapper(0.45);
   }
 }

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -13,7 +13,28 @@
 <% if current_budget.present? %>
   <div id="budget_heading" class="expanded budget main-budget-home no-margin-top">
     <div class="row" data-equalizer data-equalizer-on="medium">
-      <div class="small-12 medium-7 large-6 column padding" data-equalizer-watch>
+      <div class="column img small-12 medium-4 large-3" data-equalizer-watch>
+        <div class="main-bocadillo">
+          <div class="ellipse"></div>
+          <div class="bocadillo-text">
+            <h2 class="heading"><%=t("budgets.valladolid.my_voice") %>
+              <div class="small-bocadillo">
+                <div class="ellipse"></div>
+                <div class="bocadillo-text">
+                  <div class="title"><%=t("budgets.valladolid.va_logo") %></div>
+                </div>
+              </div>
+            </h2>
+            <%# <p class="text"><%=t("budgets.valladolid.budgets") </p>%>
+            <p class="text"><%=t("budgets.valladolid.descr_html") %></p>
+            <%# <div class="actions">
+              <span class="call"><%=t("budgets.valladolid.knowmore") </span>
+              <a class="phone" href="tel:010">010</a>
+            </div>%>
+          </div>
+        </div>
+      </div>
+      <div class="small-12 medium-5 large-6 column padding" data-equalizer-watch>
 
           <h1><%= current_budget.name %></h1>
           <div class="description">
@@ -52,11 +73,7 @@
                         class: "button margin-top expanded" %>
           <% end %>
       </div>
-      <div class="column img hide-for-small-only medium-2 large-3" data-equalizer-watch>
-        <div class="img-holder">
-          <%= image_tag "background-budgets.jpg", alt: "" %>
-        </div>
-      </div>
+
     </div>
   </div>
 

--- a/app/views/custom/budgets/show.html.erb
+++ b/app/views/custom/budgets/show.html.erb
@@ -4,7 +4,28 @@
 
 <div class="expanded budget main-budget-home no-margin-top">
   <div class="row" data-equalizer data-equalizer-on="medium">
-    <div class="small-12 medium-7 large-6 column padding" data-equalizer-watch>
+    <div class="column img small-12 medium-4 large-3" data-equalizer-watch>
+      <div class="main-bocadillo">
+        <div class="ellipse"></div>
+        <div class="bocadillo-text">
+          <h2 class="heading"><%=t("budgets.valladolid.my_voice") %>
+            <div class="small-bocadillo">
+              <div class="ellipse"></div>
+              <div class="bocadillo-text">
+                <div class="title"><%=t("budgets.valladolid.va_logo") %></div>
+              </div>
+            </div>
+          </h2>
+          <%# <p class="text"><%=t("budgets.valladolid.budgets") </p>%>
+          <p class="text"><%=t("budgets.valladolid.descr_html") %></p>
+          <%# <div class="actions">
+              <span class="call"><%=t("budgets.valladolid.knowmore") </span>
+              <a class="phone" href="tel:010">010</a>
+            </div>%>
+        </div>
+      </div>
+    </div>
+    <div class="small-12 medium-5 large-6 column padding" data-equalizer-watch>
       <% if params[:filter].present? && ['unfeasible', 'unselected'].include?(params[:filter]) %>
         <%= back_link_to budget_path(@budget) %>
       <% else %>
@@ -17,7 +38,7 @@
         <%= auto_link_already_sanitized_html wysiwyg(@budget.description) %>
       </div>
     </div>
-    <div class="small-12 medium-5 large-6 column info padding" data-equalizer-watch>
+    <div class="small-12 medium-3 large-3 column info padding" data-equalizer-watch>
       <div class="decorated-on-large">
         <p class="pre-title">
           <strong><%= t("budgets.show.phase") %></strong>

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -1,5 +1,11 @@
 es:
   budgets:
+    valladolid:
+      my_voice: Mi voz
+      va_logo: Va!
+      budgets: Presupuestos participativos
+      descr_html: "Ahora <em>yo decido</em> como mejorar <strong>mi barrio</strong> con los <em>presupuestos participativos</em>"
+      knowmore: Informate
     ballots:
       show:
         title: Mis votos


### PR DESCRIPTION
Cambio visual de la cabecera de presupuestos participativos

* Incluido el bocadillo de presupuestos participativos en sustitución de la imagen preexistente. Creado el bocadillo en modo "texto", de tal forma que se cumplan normativas de accesibilidad (todo texto debe ser un texto)
* Se incluye el bocadillo en la página de detalle de presupuesto