### PR TITLE
Hotfix/social share iframe

### DIFF
--- a/app/views/custom/layouts/_common_head.html.erb
+++ b/app/views/custom/layouts/_common_head.html.erb
@@ -59,6 +59,6 @@
 </script>
 <%else %>
   <script type="text/javascript">
-    window.location.href = 'https://www.valladolid.es/presupuestos-participativos'
+    window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>'
   </script>
 <% end %>

--- a/app/views/custom/shared/_social_share.html.erb
+++ b/app/views/custom/shared/_social_share.html.erb
@@ -2,6 +2,14 @@
 <% description = truncate(ActionView::Base.full_sanitizer.sanitize(description), length: 140) %>
 <% mobile = local_assigns[:mobile] %>
 <% mobile_url = mobile.present? ? "#{mobile.gsub(/\s+/, "%20")}%20" : "" %>
+<%
+  sharedUrl = '';
+  if(request.headers['X-Proxy-Management'] == 'proxy' || session[:iframed])
+    sharedUrl = Rails.application.secrets.participacion_iframe_source+'#'+ (u local_assigns[:url][local_assigns[:url].index('/',local_assigns[:url].index('//')+2) .. -1])
+  else
+    sharedUrl = local_assigns[:url]
+  end
+%>
 
 <% if local_assigns[:share_title].present? %>
   <div id="social-share" class="sidebar-divider"></div>
@@ -9,7 +17,7 @@
 <% end %>
 <div class="social-share-full">
   <%= social_share_button_tag("#{title} #{setting["twitter_hashtag"]} #{setting["twitter_handle"]}",
-                              url: local_assigns[:url],
+                              url: sharedUrl,
                               image: local_assigns.fetch(:image_url, ""),
                               desc: description,
                               "data-twitter-title": local_assigns[:mobile],

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -34,6 +34,8 @@ participacion: &participacion
   # Datos de pushMessage para permitir enviar información al contenedor sobre cambios
   # de altura. NO USAR '*' en producción, indicar el nombre del host valido
   participacion_push_target_origin : "*"
+  # URL del iframe contenedor, para permitir el correcto funcionamiento de la función de share
+  participacion_iframe_source: ""
 
 http_basic_auth: &http_basic_auth
   http_basic_auth: true


### PR DESCRIPTION
Permitimos que la URL de compartir no dirija a la URL sin iframe, sino que fuerce el uso de la versión embebida.
Es necesario configurar la variable `participacion_iframe_source` dentro del bloque `participacion`

Ejemplo:
```
participacion: &participacion   
   ...
   participacion_iframe_source : "https://valladolid.dvpor0033.divisait.local/participa/es/presupuestos-participativos"
```
