### PR TITLE
Ajustamos para que no fallen los enlaces externos

### DIFF
--- a/app/views/custom/layouts/_common_head.html.erb
+++ b/app/views/custom/layouts/_common_head.html.erb
@@ -55,10 +55,34 @@
       }
       window.parent.postMessage('l:' + _href, '<%=Rails.application.config.participacion_push_target_origin %>');
     });
+  } else if(window.parent === undefined || window.parent === window) {
+    var _i = window.location.href.indexOf('//');
+    if(_i>=0) {
+      _i = window.location.href.indexOf('/',_i+2);
+      if(_i>=0) {
+        var _href = window.location.href.substring(_i);
+        window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>#'+encodeURIComponent(_href);
+      } else {
+        window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>';
+      }
+    } else {
+      window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>'
+    }
   }
 </script>
 <%else %>
   <script type="text/javascript">
-    window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>'
+    var _i = window.location.href.indexOf('//');
+    if(_i>=0) {
+      _i = window.location.href.indexOf('/',_i+2);
+      if(_i>=0) {
+        window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>#'+encodeURIComponent(_href);
+      } else {
+        window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>';
+      }
+    } else {
+      window.location.href = '<%=Rails.application.secrets.participacion_iframe_source%>'
+    }
+
   </script>
 <% end %>


### PR DESCRIPTION
Se extracta la URL despues del segundo '/' y nos dirigimos a la Web principal del sistema (la contenedora)