### PR TITLE
Development ava

### DIFF
--- a/app/controllers/budgets/investments_controller.rb
+++ b/app/controllers/budgets/investments_controller.rb
@@ -247,11 +247,13 @@ module Budgets
         @map_location = MapLocation.load_from_heading(@heading)
       end
       
-      def verificar_permiso_creacion             
-          if Budget::Investment.valuating_investment(current_user, @budget.id).exists?           
-            redirect_to budgets_path, alert: t("budgets.investments.index.sidebar.message_error_my_count")
-          end        
+     def verificar_permiso_creacion
+      if !current_user.organization? && Budget::Investment.valuating_investment(current_user.id, @budget.id).count > 0
+        redirect_to budgets_path, alert: t("budgets.investments.index.sidebar.message_error_my_count")
+      elsif current_user.organization? && Budget::Investment.valuating_investment_number(current_user.id, @budget.id).count > 4
+        redirect_to budgets_path, alert: t("budgets.investments.index.sidebar.message_error_my_propuestas")
       end
+    end
 
   end
 end

--- a/app/models/budget/investment.rb
+++ b/app/models/budget/investment.rb
@@ -95,6 +95,7 @@ class Budget
     scope :sort_by_created_at,          -> { reorder(created_at: :desc) }
     scope :zona_mesa,                   -> { selected.compatible.where(zona_mesa: true) }
     scope :valuating_investment,        ->(user_id, budget_id)  { valuation_open.where(author_id: user_id ).where(budget_id: budget_id).where("hidden_at IS ?", nil) }
+    scope :valuating_investment_number, ->(user_id, budget_id)  { valuation_open.where(author_id: user_id ).where(budget_id: budget_id).where("hidden_at IS ?", nil) }
 
     scope :by_budget,         ->(budget)      { where(budget: budget) }
     scope :by_group,          ->(group_id)    { where(group_id: group_id) }
@@ -108,7 +109,6 @@ class Budget
     def valuating_investment?
       valuating_investment.count > 0
     end
-
 
     def self.by_valuator(valuator_id)
       where("budget_valuator_assignments.valuator_id = ?", valuator_id).joins(:valuator_assignments)

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -33,8 +33,22 @@
 
           <% if current_budget.accepting? %>
             <% if current_user %>
-              <% if can?(:create, Budget::Investment.new(budget: current_budget)) %>     
-                  <% if Budget::Investment.valuating_investment(current_user, current_budget).exists? %>
+              <% if can?(:create, Budget::Investment.new(budget: current_budget)) %>    
+                  <% if !current_user.organization? && Budget::Investment.valuating_investment(current_user.id, current_budget.id).count > 0 %> 
+                     <div class="callout primary margin-top">
+                      <%= sanitize(
+                            t("budgets.investments.index.sidebar.my_count",
+                              link_my_count: link_to(
+                                t("budgets.investments.index.sidebar.link_my_count"),
+                                user_path(current_user),
+                                rel: "nofollow",
+                                title: t("budgets.investments.index.sidebar.link_my_count"),
+                                class: "my_count-link #{'active' if controller_name == 'users'}"
+                              )
+                            )
+                          ) %>
+                      </div>
+                    <% elsif current_user.organization? && Budget::Investment.valuating_investment_number(current_user.id, current_budget.id).count > 4 %> 
                      <div class="callout primary margin-top">
                       <%= sanitize(
                             t("budgets.investments.index.sidebar.my_count",

--- a/app/views/custom/welcome/index.html.erb
+++ b/app/views/custom/welcome/index.html.erb
@@ -42,7 +42,7 @@
 <div class="row expanded homepage-tu-voz">
   <div class="row">
     <div class="small-12 medium-offset-1 medium-4 column margin-top margin-bottom">
-      <%= image_tag 'logo_decide_blanco.png', size: "439x280", alt: "Decide presupuestos participativos Valladolid", style: "opacity: 0.85" %>
+      <%= image_tag 'logo_decide_blanco.png', size: "439x280", alt: "Decide presupuestos participativos Valladolid" %>
     </div>
     <div class="small-12 medium-6 column margin-top margin-bottom">
       <div class="margin"></div>

--- a/config/locales/custom/es/pages.yml
+++ b/config/locales/custom/es/pages.yml
@@ -378,7 +378,7 @@ es:
         <p>El Ayuntamiento de Valladolid se reserva el derecho de revisar las presentes condiciones de uso y la política de privacidad en cualquier momento y por cualquier razón. En dicho caso, los usuarios registrados serán avisados a través de este espacio en línea y, si continúan utilizando el Portal de eParticipación, se entenderán aceptadas las modificaciones introducidas.</p>
     login:
       codigos:
-        title: "Identifícate para votar"
+        title: "Identifícate"
         instructions: "Introduce tu DNI y el código incluído en el SMS o en la carta que hemos enviado a tu domicilio. Si no dispones de DNI introduce tu NIE o Pasaporte. En todos los casos recuerda introducir el documento incluyendo la letra o letras en mayúsculas, sin incluír puntos, espacios o guiones."
         help: "Si no dispones de código, puedes %{login} con tu cuenta o si no dispones de una, registrarla %{register}, pero recuerda que para poder votar tendrás que verificar dicha cuenta."
         help_login: "acceder"

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -106,6 +106,7 @@ es:
           my_count: "Ya ha creado un proyecto de gasto, si quiere cambiarlo vaya a %{link_my_count}."
           link_my_count: Mi contenido
           message_error_my_count: "No tienes permiso para acceder a esta página."
+          message_error_my_propuestas: "Ya ha creado 5 propuestas de proyecto, no puede crear ninguna propuesta más."
         orders:
           random: Aleatorios
           confidence_score: Mejor valorados


### PR DESCRIPTION
1.	Modificaciones para que no deje crear propuestas si:
- Es una organización: no deje más de 5 para el mismo Presupuesto participativo
- ciudadanos: no deje más de 1 para el mismo Presupuesto participativo
2.	Quitar el “para votar” de la pantalla de entrada de los usuarios por DNI y código
 
