### PR TITLE
Modificaciones para que:

### DIFF
--- a/app/views/custom/codigos/new.html.erb
+++ b/app/views/custom/codigos/new.html.erb
@@ -10,11 +10,12 @@
 		<%= submit_tag nil, :class => 'button expanded' %>
 	<% end %>
 	<p>
-		<%= raw t("pages.login.codigos.help",
-					login: link_to(t("pages.login.codigos.help_login"), new_user_session_path),
-					register: link_to(t("pages.login.codigos.help_register"), new_user_registration_path)
-				)
-		%>
+	   <%= raw t("pages.login.codigos.help",
+    		login: link_to(t("pages.login.codigos.help_login"), new_user_session_path),
+    		register: link_to(t("pages.login.codigos.help_register"), 
+                        new_user_registration_path)
+    		)
+ 	   %>	
 	</p>
 </div>
 </div>

--- a/app/views/custom/devise/menu/_login_items.html.erb
+++ b/app/views/custom/devise/menu/_login_items.html.erb
@@ -22,6 +22,6 @@
 <% else %>
   <li id="login-va">
     <%= link_to t("devise_views.menu.login_items.login"),
-                user_codigo_omniauth_authorize_path, rel: "nofollow", class: "button", method: :post %>
+                new_user_session_path, rel: "nofollow", class: "button", method: :post %>
   </li>
 <% end %>

--- a/app/views/devise/menu/_login_items.html.erb
+++ b/app/views/devise/menu/_login_items.html.erb
@@ -20,12 +20,10 @@
                 destroy_user_session_path, rel: "nofollow", method: :delete %>
   </li>
 <% else %>
-  <li>
+  <li id="login-va">
     <%= link_to t("devise_views.menu.login_items.login"),
-                new_user_session_path, rel: "nofollow" %>
-  </li>
-  <li>
-    <%= link_to t("devise_views.menu.login_items.signup"),
-                new_user_registration_path, rel: "nofollow", class: "button" %>
+            new_user_session_path, 
+            rel: "nofollow", 
+            class: "button" %>
   </li>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -7,6 +7,12 @@
   <%= sanitize(t("devise_views.shared.links.signup",
       signup_link: link_to(t("devise_views.shared.links.signup_link"), new_user_registration_path))) %>
 </p>
+<p>
+  <%= link_to t("devise_views.shared.links.acceso_codigo_link"),
+            user_codigo_omniauth_authorize_path,
+            method: :post,
+            data: { turbo: false } %>
+</p>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="row">

--- a/config/locales/es/devise_views.yml
+++ b/config/locales/es/devise_views.yml
@@ -81,6 +81,7 @@ es:
         signin_with_provider: Entrar con %{provider}
         signup: '¿No tienes una cuenta? %{signup_link}'
         signup_link: Regístrate
+        acceso_codigo_link: 'Si tienes un código, accede por DNI + código en este enlace.'
     unlocks:
       new:
         email_label: Email


### PR DESCRIPTION
Modificaciones para que:

•	Quieren que el acceso por defecto (botón Entrar) sea por cuenta en vez de código (/presupuestosparticipativos/users/sign_in vs /presupuestosparticipativos/users/auth/codigo)
•	Añadir en la página de acceso por cuenta un enlace a acceder por código (por ejemplo, debajo del "¿No tienes una cuenta? Regístrate")
o	El texto puede ser "Si tienes un código, accede por DNI + código en este enlace." [enlazando todo el texto]
