### PR TITLE
Feature/r4792 en zona no apoyo mensaje correcto

### DIFF
--- a/app/views/admin/dashboard/actions/_form.html.erb
+++ b/app/views/admin/dashboard/actions/_form.html.erb
@@ -73,7 +73,7 @@
 </div>
 
 <div class="row expanded">
-  <div class="small-12 medium-6 large-4 column">
+  <div class="small-12 medium-6 column">
     <%= f.submit(class: "button expanded", value: t("admin.dashboard.actions.form.submit_button")) %>
   </div>
 </div>

--- a/app/views/budgets/index.html.erb
+++ b/app/views/budgets/index.html.erb
@@ -30,25 +30,36 @@
           <%= link_to t("budgets.index.section_header.all_phases"), "#all_phases" %>
 
           <% if current_budget.accepting? %>
-            <% if current_user %>
-              <% if current_user.level_two_or_three_verified? %>
-                    <%= link_to t("budgets.investments.index.sidebar.create"),
-                                new_budget_investment_path(current_budget),
-                                class: "button margin-top expanded" %>  
-              <% else %>
-                <div class="callout warning margin-top">
-                  <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
-                        verify: link_to_verify_account)) %>
-                </div>
-              <% end %>
-            <% else %>
-              <div class="callout primary margin-top">
-                <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
-                      sign_in: link_to_signin, sign_up: link_to_signup)) %>
-              </div>
-            <% end %>
-          <% end %>
-
+			  <% if current_user %>
+			    <% if current_user.level_two_or_three_verified? %>
+			      <%= link_to t("budgets.investments.index.sidebar.create"),
+			                  new_budget_investment_path(current_budget),
+			                  class: "button margin-top expanded" %>  
+			    <% else %>
+			      <div class="callout warning margin-top">
+			        <%= sanitize(t("budgets.investments.index.sidebar.verified_only",
+			                       verify: link_to_verify_account)) %>
+			      </div>
+			    <% end %>
+			  <% else %>
+			    <div class="callout primary margin-top">
+			      <% if faseapoyo? %>
+			        <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        user_codigo_omniauth_authorize_path,
+			                                        method: :post,
+			                                        data: { turbo: false }),
+			                       sign_up: link_to_signup)) %>
+			      <% else %>
+			         <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        new_user_session_path,
+			                                        rel: "nofollow"),
+			                       sign_up: link_to_signup)) %>	
+			      <% end %>
+			    </div>
+			  <% end %>
+			<% end %>
         <% if can?(:read_results, current_budget) %>
           <%= link_to t("budgets.show.see_results"),
                       budget_results_path(current_budget, heading_id: current_budget.headings.first),

--- a/app/views/budgets/investments/_form.html.erb
+++ b/app/views/budgets/investments/_form.html.erb
@@ -99,7 +99,7 @@
 
     <% end %>
 
-    <div class="actions small-12 medium-6 large-4 end column">
+    <div class="actions small-12 medium-6 end column">
       <%= f.submit(nil, class: "button expanded") %>
     </div>
   </div>

--- a/app/views/budgets/show.html.erb
+++ b/app/views/budgets/show.html.erb
@@ -29,8 +29,20 @@
           <% end %>
         <% else %>
           <div class="callout primary margin-top">
-            <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
-                  sign_in: link_to_signin, sign_up: link_to_signup)) %>
+			<% if faseapoyo? %>
+			        <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        user_codigo_omniauth_authorize_path,
+			                                        method: :post,
+			                                        data: { turbo: false }),
+			                       sign_up: link_to_signup)) %>
+			      <% else %>
+			         <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        new_user_session_path,
+			                                        rel: "nofollow"),
+			                       sign_up: link_to_signup)) %>	
+			      <% end %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/custom/budgets/index.html.erb
+++ b/app/views/custom/budgets/index.html.erb
@@ -72,8 +72,20 @@
               <% end %>
             <% else %>
               <div class="callout primary margin-top">
-                <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
-                      sign_in: link_to_signin, sign_up: link_to_signup)) %>
+                <% if faseapoyo? %>
+			        <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        user_codigo_omniauth_authorize_path,
+			                                        method: :post,
+			                                        data: { turbo: false }),
+			                       sign_up: link_to_signup)) %>
+			      <% else %>
+			        <%= sanitize(t("budgets.investments.index.sidebar.not_logged_in",
+			                       sign_in: link_to(t("users.signin"),
+			                                        new_user_session_path,
+			                                        rel: "nofollow"),
+			                       sign_up: link_to_signup)) %>	  
+			      <% end %>         
               </div>
             <% end %>
           <% end %>

--- a/app/views/custom/budgets/investments/_form.html.erb
+++ b/app/views/custom/budgets/investments/_form.html.erb
@@ -107,7 +107,7 @@
 
     <% end %>
 
-    <div class="actions small-12 medium-6 large-4 end column">
+    <div class="actions small-12 medium-6 end column">
       <%= f.submit(nil, class: "button expanded") %>
     </div>
   </div>

--- a/app/views/custom/budgets/investments/_sidebar.html.erb
+++ b/app/views/custom/budgets/investments/_sidebar.html.erb
@@ -2,8 +2,38 @@
 
 <% if can?(:create, Budget::Investment.new(budget: @budget)) %>
   <% if current_user %>
-    <%= link_to t("budgets.investments.index.sidebar.create"),
-               new_budget_investment_path(budget_id: @budget.id), class: "button budget expanded" %>
+     <% if !current_user.organization? && Budget::Investment.valuating_investment(current_user.id, @budget.id).count > 0 %> 
+                      <div class="callout primary margin-top">
+                        <%= sanitize(
+                              t("budgets.investments.index.sidebar.my_count",
+                                link_my_count: link_to(
+                                  t("budgets.investments.index.sidebar.link_my_count"),
+                                  user_path(current_user),
+                                  rel: "nofollow",
+                                  title: t("budgets.investments.index.sidebar.link_my_count"),
+                                  class: "my_count-link #{'active' if controller_name == 'users'}"
+                                )
+                              )
+                            ) %>
+                        </div>
+       <% elsif current_user.organization? && Budget::Investment.valuating_investment_number(current_user.id, @budget.id).count > 4 %> 
+                     <div class="callout primary margin-top">
+                      <%= sanitize(
+                            t("budgets.investments.index.sidebar.my_count",
+                              link_my_count: link_to(
+                                t("budgets.investments.index.sidebar.link_my_count"),
+                                user_path(current_user),
+                                rel: "nofollow",
+                                title: t("budgets.investments.index.sidebar.link_my_count"),
+                                class: "my_count-link #{'active' if controller_name == 'users'}"
+                              )
+                            )
+                          ) %>
+                      </div>
+      <% else %>
+          <%= link_to t("budgets.investments.index.sidebar.create"),
+                new_budget_investment_path(budget_id: @budget.id), class: "button budget expanded" %>
+      <% end %>
   <% else %>
     <div class="callout warning">
       <%= sanitize(t("budgets.investments.index.sidebar.verified_only",

--- a/app/views/custom/devise/shared/_links.html.erb
+++ b/app/views/custom/devise/shared/_links.html.erb
@@ -1,6 +1,17 @@
 <div class="text-center">
   <%- if controller_name != "sessions" %>
-    <%= link_to t("devise_views.shared.links.login"), new_session_path(resource_name) %><br>
+    <% if faseapoyo? %>
+      <%= link_to t("devise_views.menu.login_items.login"),
+                  user_codigo_omniauth_authorize_path,
+                  method: :post,
+                  data: { turbo: false },
+                  rel: "nofollow" %>
+      <% else %>
+        <%= link_to t("devise_views.menu.login_items.login"),
+                    new_user_session_path, 
+                    rel: "nofollow" %>
+      <% end %>   
+       <br>
   <% end -%>
 
   <%#- if devise_mapping.registerable? &&

--- a/app/views/devise/menu/_login_items.html.erb
+++ b/app/views/devise/menu/_login_items.html.erb
@@ -20,10 +20,17 @@
                 destroy_user_session_path, rel: "nofollow", method: :delete %>
   </li>
 <% else %>
-  <li id="login-va">
-    <%= link_to t("devise_views.menu.login_items.login"),
-            new_user_session_path, 
-            rel: "nofollow", 
-            class: "button" %>
-  </li>
+ <% if faseapoyo? %>
+      <%= link_to t("devise_views.menu.login_items.login"),
+                  user_codigo_omniauth_authorize_path,
+                  method: :post,
+                  data: { turbo: false },
+                  rel: "nofollow",
+                  class: "button" %>
+    <% else %>
+      <%= link_to t("devise_views.menu.login_items.login"),
+                  new_user_session_path, 
+                  rel: "nofollow", 
+                  class: "button" %>
+    <% end %>
 <% end %>

--- a/config/locales/custom/es/budgets.yml
+++ b/config/locales/custom/es/budgets.yml
@@ -63,7 +63,7 @@ es:
           not_logged_in: "Para crear una nueva propuesta de proyecto de inversión debes %{sign_in} o %{sign_up}."
           feasible: Ver las propuestas viables
           unfeasible: Ver las propuestas inviables
-          my_count: "Ya ha creado una propuesta de proyecto de inversión, si quiere cambiarlo vaya a %{link_my_count}."
+          my_count: "Ya ha creado el máximo de propuestas de proyectos de inversión, si quiere cambiarlo vaya a %{link_my_count}."
       share:
         message: "He presentado la propuesta de proyecto de inversión %{title} en %{handle}. ¡Presenta una propuesta tú también!"
       show:

--- a/config/locales/es/budgets.yml
+++ b/config/locales/es/budgets.yml
@@ -103,7 +103,7 @@ es:
           by_feasibility: Por viabilidad
           feasible: Ver los proyectos viables
           unfeasible: Ver los proyectos inviables
-          my_count: "Ya ha creado un proyecto de gasto, si quiere cambiarlo vaya a %{link_my_count}."
+          my_count: "Ya ha creado el máximo de propuestas de proyectos de inversión, si quiere cambiarlo vaya a %{link_my_count}."
           link_my_count: Mi contenido
           message_error_my_count: "No tienes permiso para acceder a esta página."
           message_error_my_propuestas: "Ya ha creado 5 propuestas de proyecto, no puede crear ninguna propuesta más."


### PR DESCRIPTION
* Modificaciones:

- Desde la página de Presupuestos participativos (http://vmconsulpre/presupuestosparticipativos/budgets) sin loguear sale un mensaje para iniciar sesión o registrarse que va a la página de códigos -> debería ir a la de usuario/contraseña:

- En general, revisar según los distintos estados (si hay enlace, debería ir al acceso por código si está en apoyos o en votación final, pero no en el resto como en Presentación de propuestas)
- Cuando se entre en una zona si no se puede dar apoyo salga en mensaje correcto y no el botón
- Botón más largo en la creación de propuestas


