### PR TITLE
Feature/R4792 en zona no apoyo mensaje correcto

### DIFF
--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -20,7 +20,7 @@ es:
       not_found_in_database: "%{authentication_keys} o contraseña inválidos."
       timeout: "Tu sesión ha expirado, por favor inicia sesión nuevamente para continuar."
       unauthenticated: "Necesitas iniciar sesión o registrarte para continuar."
-      unconfirmed: "Para continuar, por favor pulsa en el enlace de confirmación que hemos enviado a tu cuenta de correo."
+      unconfirmed: "No has confirmado tu cuenta, por favor pulsa en el enlace de confirmación que hemos enviado a tu correo electrónico."
     mailer:
       confirmation_instructions:
         subject: "Instrucciones de confirmación"

--- a/lib/devise_custom_failure_app.rb
+++ b/lib/devise_custom_failure_app.rb
@@ -9,7 +9,7 @@ class DeviseCustomFailureApp < Devise::FailureApp
       opts[:script_name] = nil
 
       # Custom route
-      route = :new_codigo_url
+      route = :new_user_session_url
 
       opts[:format] = request_format unless skip_format?
 


### PR DESCRIPTION
* Modificación:

• Cuando te registras e intentas "loguearte" sin haber confirmado (pinchar enlace en el correo de confirmación), te lleva a la página de confirmación por código (http://vmconsulpre/presupuestosparticipativos/codigos/new) aunque estés en la página de acceso por usuario/contraseña -> debería llevar a la que estabas (usuario+contraseña, que además es la única desde donde puede dar este error)
