### PR TITLE
Modificaciones para incluir en el asunto del correo de confirmación el nombre del usuario u organización

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -3,6 +3,29 @@ class DeviseMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers
   default template_path: "devise/mailer"
 
+  def confirmation_instructions(record, token, opts = {})
+    @token = token
+    
+    Rails.logger.info "====== CONFIRMATION INSTRUCTIONS ======"
+    Rails.logger.info "Record class: #{record.class.name}"
+    Rails.logger.info "Es organización?: #{record.organization?}"
+    
+    # Usa el método name del modelo User que ya maneja esto
+    display_name = record.name.presence || record.email
+    
+    Rails.logger.info "Display name: #{display_name}"
+    
+    opts[:subject] = I18n.t(
+      'devise.mailer.confirmation_instructions.subject',
+      name: display_name
+    )
+    
+    Rails.logger.info "Subject generado: #{opts[:subject]}"
+    Rails.logger.info "======================================="
+    
+    super(record, token, opts)
+  end
+
   protected
 
     def devise_mail(record, action, opts = {})
@@ -10,4 +33,5 @@ class DeviseMailer < Devise::Mailer
         super(record, action, opts)
       end
     end
+
 end

--- a/config/locales/es/devise.yml
+++ b/config/locales/es/devise.yml
@@ -23,7 +23,7 @@ es:
       unconfirmed: "No has confirmado tu cuenta, por favor pulsa en el enlace de confirmación que hemos enviado a tu correo electrónico."
     mailer:
       confirmation_instructions:
-        subject: "Instrucciones de confirmación"
+        subject: "Instrucciones de confirmación para %{name}"
       reset_password_instructions:
         subject: "Instrucciones para restablecer tu contraseña"
       unlock_instructions:

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -10,7 +10,9 @@ describe DeviseMailer do
       end
 
       expect(email.subject).to include("confirmación")
+      expect(email.subject).to include(user.name) # Verifica que incluya el nombre generado
     end
+    
 
     it "reads the from address at runtime" do
       Setting["mailer_from_name"] = "New organization"


### PR DESCRIPTION
Modificaciones para incluir en el asunto del correo de confirmación el nombre del usuario u organización